### PR TITLE
Activity only workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,32 @@ public class SomeActivityImpl implements SomeActivity {
 }
 ```
 
+If you would like to have the activity on separate worker add `@TemporalActivity` annotation:
+```java
+@Service
+@TemporalActivity("SomeName")
+public class SomeActivityImpl implements SomeActivity {
+  public String say(String string) {
+    ...
+  }
+}
+```
+
+And add parameters to set task queue and optionally worker parameters:
+
+```yaml
+  activityWorkerDefaults:
+    activityPoolSize: 9
+   activityWorkers:
+    SomeName:
+      activityPoolSize: 10
+      taskQueue: someActivityQueue
+
+```
+
+If you do so remember to add `taskQueue` parameter to annotation of the activity stub on the workflow as well.
+You can find example of such a process in `samples/app` folder in the tests `HelloActivitySepareteWorker.java`.
+
 ### Calling your workflow
 
 To call your workflow you will need `WorkflowFactory` an one of its many
@@ -195,5 +221,5 @@ spring.temporal:
 You can also disable creation of workflows for given test when testing using annotation `@TemporalTest`
 ### Writing tests
 
-Pleas look into test directory `samples` folder in the sources.
+Please look into test directory `samples` folder in the sources.
 

--- a/src/main/java/ai/applica/spring/boot/starter/temporal/annotations/TemporalActivity.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/annotations/TemporalActivity.java
@@ -23,18 +23,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * To mark activiti on a Workflow to make it a stub. One must specify duration and can specify
- * duration unit being ChronoUnit string equivalent.
+ * Indicates that service is an appropriate temporal activity implementation one must specify name
+ * of activity for parameters retrieval.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD})
-public @interface ActivityStub {
-
-  long duration() default -1;
-
-  String durationUnits() default "SECONDS";
-
-  RetryActivityOptions retryOptions() default @RetryActivityOptions;
-
-  String taskQueue() default "";
+@Target({ElementType.TYPE})
+public @interface TemporalActivity {
+  /** Link to activity properties to be loaded from config */
+  String value();
 }

--- a/src/main/java/ai/applica/spring/boot/starter/temporal/config/TemporalProperties.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/config/TemporalProperties.java
@@ -37,13 +37,19 @@ public class TemporalProperties {
 
   private WorkflowOption workflowDefaults;
 
+  private WorkflowOption activityWorkerDefaults;
+
   private Map<String, WorkflowOption> workflows;
+
+  private Map<String, WorkflowOption> activityWorkers;
 
   private ActivityStubOptions activityStubDefaults;
 
   private Map<String, ActivityStubOptions> activityStubs;
 
   private boolean addedDefaultsToWorkflows = false;
+
+  private boolean addedDefaultsToActivities = false;
 
   @Data
   @NoArgsConstructor
@@ -64,6 +70,8 @@ public class TemporalProperties {
   @NoArgsConstructor
   public static class ActivityStubOptions {
 
+    private String taskQueue;
+
     private Long scheduleToCloseTimeout;
 
     private String scheduleToCloseTimeoutUnit;
@@ -73,6 +81,30 @@ public class TemporalProperties {
     if (!addedDefaultsToWorkflows) {
       synchronized (this) {
         workflows.forEach(
+            (key, value) -> {
+              if (value.getExecutionTimeout() == null) {
+                value.setExecutionTimeout(workflowDefaults.getExecutionTimeout());
+              }
+              if (value.getExecutionTimeoutUnit() == null) {
+                value.setExecutionTimeoutUnit(workflowDefaults.getExecutionTimeoutUnit());
+              }
+              if (value.getActivityPoolSize() == null) {
+                value.setActivityPoolSize(workflowDefaults.getActivityPoolSize());
+              }
+              if (value.getWorkflowPoolSize() == null) {
+                value.setWorkflowPoolSize(workflowDefaults.getWorkflowPoolSize());
+              }
+              addedDefaultsToWorkflows = true;
+            });
+      }
+    }
+    return workflows;
+  }
+
+  public Map<String, WorkflowOption> activityWorkers() {
+    if (!addedDefaultsToActivities) {
+      synchronized (this) {
+        activityWorkers.forEach(
             (key, value) -> {
               if (value.getExecutionTimeout() == null) {
                 value.setExecutionTimeout(workflowDefaults.getExecutionTimeout());

--- a/src/main/java/ai/applica/spring/boot/starter/temporal/config/TemporalProperties.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/config/TemporalProperties.java
@@ -101,27 +101,27 @@ public class TemporalProperties {
     return workflows;
   }
 
-  public Map<String, WorkflowOption> activityWorkers() {
+  public Map<String, WorkflowOption> getActivityWorkers() {
     if (!addedDefaultsToActivities) {
       synchronized (this) {
         activityWorkers.forEach(
             (key, value) -> {
               if (value.getExecutionTimeout() == null) {
-                value.setExecutionTimeout(workflowDefaults.getExecutionTimeout());
+                value.setExecutionTimeout(activityWorkerDefaults.getExecutionTimeout());
               }
               if (value.getExecutionTimeoutUnit() == null) {
-                value.setExecutionTimeoutUnit(workflowDefaults.getExecutionTimeoutUnit());
+                value.setExecutionTimeoutUnit(activityWorkerDefaults.getExecutionTimeoutUnit());
               }
               if (value.getActivityPoolSize() == null) {
-                value.setActivityPoolSize(workflowDefaults.getActivityPoolSize());
+                value.setActivityPoolSize(activityWorkerDefaults.getActivityPoolSize());
               }
               if (value.getWorkflowPoolSize() == null) {
-                value.setWorkflowPoolSize(workflowDefaults.getWorkflowPoolSize());
+                value.setWorkflowPoolSize(activityWorkerDefaults.getWorkflowPoolSize());
               }
-              addedDefaultsToWorkflows = true;
+              addedDefaultsToActivities = true;
             });
       }
     }
-    return workflows;
+    return activityWorkers;
   }
 }

--- a/src/main/java/ai/applica/spring/boot/starter/temporal/processors/ActivityAnnotationBeanPostProcessor.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/processors/ActivityAnnotationBeanPostProcessor.java
@@ -1,0 +1,107 @@
+/*
+ *  Copyright (c) 2020 Applica.ai All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package ai.applica.spring.boot.starter.temporal.processors;
+
+import ai.applica.spring.boot.starter.temporal.annotations.TemporalActivity;
+import ai.applica.spring.boot.starter.temporal.config.TemporalProperties;
+import ai.applica.spring.boot.starter.temporal.config.TemporalProperties.WorkflowOption;
+import io.temporal.worker.Worker;
+import io.temporal.worker.WorkerFactory;
+import io.temporal.worker.WorkerOptions;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationUtils;
+
+@Slf4j
+@Configuration
+@Profile("!temporal_test")
+@RequiredArgsConstructor
+public class ActivityAnnotationBeanPostProcessor
+    implements BeanPostProcessor, Ordered, SmartInitializingSingleton {
+
+  private final TemporalProperties temporalProperties;
+  private final WorkerFactory workerFactory;
+  private final Set<String> classes = new HashSet<>();
+
+  @Override
+  public Object postProcessBeforeInitialization(Object bean, String beanName)
+      throws BeansException {
+    return bean;
+  }
+
+  @Override
+  public Object postProcessAfterInitialization(final Object bean, final String beanName)
+      throws BeansException {
+
+    if (!temporalProperties.isCreateWorkers() || classes.contains(bean.getClass().getName())) {
+      return bean;
+    }
+
+    Class<?> targetClass = AopUtils.getTargetClass(bean);
+    TemporalActivity activityAnotation =
+        AnnotationUtils.findAnnotation(targetClass, TemporalActivity.class);
+
+    if (activityAnotation == null) {
+      return bean;
+    }
+
+    log.info("Registering activiti worker for {}", targetClass);
+
+    Map<String, WorkflowOption> activityWorkersProperties = temporalProperties.getActivityWorkers();
+    String value = activityAnotation.value();
+    WorkflowOption options = activityWorkersProperties.get(value);
+    if (options == null) {
+      throw new RuntimeException("No configuration defined for activityWorker: " + value);
+    }
+    Worker worker = workerFactory.newWorker(options.getTaskQueue(), getWorkerOptions(options));
+
+    worker.registerActivitiesImplementations(bean);
+
+    classes.add(bean.getClass().getName());
+    return bean;
+  }
+
+  private WorkerOptions getWorkerOptions(WorkflowOption option) {
+    return WorkerOptions.newBuilder()
+        .setMaxConcurrentActivityExecutionSize(option.getActivityPoolSize())
+        .setMaxConcurrentWorkflowTaskExecutionSize(option.getWorkflowPoolSize())
+        .build();
+  }
+
+  @Override
+  public void afterSingletonsInstantiated() {
+    if (temporalProperties.isCreateWorkers()) {
+      workerFactory.start();
+    }
+  }
+
+  @Override
+  public int getOrder() {
+    return LOWEST_PRECEDENCE;
+  }
+}

--- a/src/main/java/ai/applica/spring/boot/starter/temporal/processors/ActivityAnnotationBeanPostProcessor.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/processors/ActivityAnnotationBeanPostProcessor.java
@@ -87,10 +87,13 @@ public class ActivityAnnotationBeanPostProcessor
   }
 
   private WorkerOptions getWorkerOptions(WorkflowOption option) {
-    return WorkerOptions.newBuilder()
-        .setMaxConcurrentActivityExecutionSize(option.getActivityPoolSize())
-        .setMaxConcurrentWorkflowTaskExecutionSize(option.getWorkflowPoolSize())
-        .build();
+    WorkerOptions.Builder workerOptions =
+        WorkerOptions.newBuilder()
+            .setMaxConcurrentActivityExecutionSize(option.getActivityPoolSize());
+    if (option.getWorkflowPoolSize() != null) {
+      workerOptions.setMaxConcurrentWorkflowTaskExecutionSize(option.getWorkflowPoolSize());
+    }
+    return workerOptions.build();
   }
 
   @Override

--- a/src/main/java/ai/applica/spring/boot/starter/temporal/processors/ActivityStubInterceptor.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/processors/ActivityStubInterceptor.java
@@ -45,6 +45,7 @@ import net.bytebuddy.implementation.bind.annotation.This;
 import org.springframework.core.MethodIntrospector;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -93,7 +94,7 @@ public class ActivityStubInterceptor {
 
     // Build default options
     Builder options = ActivityOptions.newBuilder();
-    if (!"".equals(activityStubAnnotation.taskQueue())) {
+    if (StringUtils.hasText(activityStubAnnotation.taskQueue())) {
       options.setTaskQueue(activityStubAnnotation.taskQueue());
     }
     // from configuration

--- a/src/main/java/ai/applica/spring/boot/starter/temporal/processors/ActivityStubInterceptor.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/processors/ActivityStubInterceptor.java
@@ -93,7 +93,9 @@ public class ActivityStubInterceptor {
 
     // Build default options
     Builder options = ActivityOptions.newBuilder();
-
+    if (!"".equals(activityStubAnnotation.taskQueue())) {
+      options.setTaskQueue(activityStubAnnotation.taskQueue());
+    }
     // from configuration
     if (temporalProperties.getActivityStubDefaults() != null) {
       ActivityStubOptions activityStubDefaults = temporalProperties.getActivityStubDefaults();
@@ -125,6 +127,9 @@ public class ActivityStubInterceptor {
       ActivityStubOptions applicableOptions =
           stubMap.getOrDefault(fullStubName, stubMap.get(simpleStubName));
       if (applicableOptions != null) {
+        if (applicableOptions.getTaskQueue() != null) {
+          options.setTaskQueue(applicableOptions.getTaskQueue());
+        }
         options.setScheduleToCloseTimeout(
             Duration.of(
                 applicableOptions.getScheduleToCloseTimeout(),

--- a/src/main/java/ai/applica/spring/boot/starter/temporal/processors/WorkflowAnnotationBeanPostProcessor.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/processors/WorkflowAnnotationBeanPostProcessor.java
@@ -146,10 +146,13 @@ public class WorkflowAnnotationBeanPostProcessor
   }
 
   private WorkerOptions getWorkerOptions(WorkflowOption option) {
-    return WorkerOptions.newBuilder()
-        .setMaxConcurrentActivityExecutionSize(option.getActivityPoolSize())
-        .setMaxConcurrentWorkflowTaskExecutionSize(option.getWorkflowPoolSize())
-        .build();
+    WorkerOptions.Builder workerOptions =
+        WorkerOptions.newBuilder()
+            .setMaxConcurrentWorkflowTaskExecutionSize(option.getWorkflowPoolSize());
+    if (option.getActivityPoolSize() != null) {
+      workerOptions.setMaxConcurrentActivityExecutionSize(option.getActivityPoolSize());
+    }
+    return workerOptions.build();
   }
 
   @Override

--- a/src/test/java/ai/applica/spring/boot/starter/temporal/HelloWorkflowImplTwo.java
+++ b/src/test/java/ai/applica/spring/boot/starter/temporal/HelloWorkflowImplTwo.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component;
 @TemporalWorkflow("two")
 public class HelloWorkflowImplTwo implements HelloWorkflow {
 
-  @ActivityStub(duration = 10)
+  @ActivityStub(taskQueue = "SimpleActivity", duration = 10)
   private SimpleService simpleService;
 
   @Override

--- a/src/test/java/ai/applica/spring/boot/starter/temporal/SimpleServiceImpl.java
+++ b/src/test/java/ai/applica/spring/boot/starter/temporal/SimpleServiceImpl.java
@@ -17,9 +17,11 @@
 
 package ai.applica.spring.boot.starter.temporal;
 
+import ai.applica.spring.boot.starter.temporal.annotations.TemporalActivity;
 import org.springframework.stereotype.Service;
 
 @Service
+@TemporalActivity("SimpleActivity")
 public class SimpleServiceImpl implements SimpleService {
   public String say(String sth) {
     System.out.println(sth);

--- a/src/test/java/ai/applica/spring/boot/starter/temporal/samples/HelloActivitySeparateWorkerTest.java
+++ b/src/test/java/ai/applica/spring/boot/starter/temporal/samples/HelloActivitySeparateWorkerTest.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2020 Applica.ai All Rights Reserved
+ *
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package ai.applica.spring.boot.starter.temporal.samples;
+
+import static org.junit.Assert.assertEquals;
+
+import ai.applica.spring.boot.starter.temporal.WorkflowFactory;
+import ai.applica.spring.boot.starter.temporal.annotations.TemporalTest;
+import ai.applica.spring.boot.starter.temporal.samples.apps.HelloActivitySepareteWorker.GreetingActivities;
+import ai.applica.spring.boot.starter.temporal.samples.apps.HelloActivitySepareteWorker.GreetingSeparateWorkflow;
+import ai.applica.spring.boot.starter.temporal.samples.apps.HelloActivitySepareteWorker.GreetingWorkflowImpl;
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.worker.Worker;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/** Unit test for {@link HelloActivitySepareteWorker}. Doesn't use an external Temporal service. */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@TemporalTest
+public class HelloActivitySeparateWorkerTest {
+
+  static final String ACTIVITY_TASK_QUEUE = "HelloActivitySepareteWorkerActivity";
+
+  private TestWorkflowEnvironment testEnv;
+  GreetingSeparateWorkflow workflow;
+
+  @Autowired WorkflowFactory fact;
+  @Autowired GreetingActivities greatActivity;
+
+  @Before
+  public void setUp() {
+    testEnv = TestWorkflowEnvironment.newInstance();
+    fact.makeWorker(testEnv, GreetingWorkflowImpl.class);
+
+    // Get a workflow stub using the same task queue the worker uses.
+    workflow =
+        fact.makeStub(
+            GreetingSeparateWorkflow.class,
+            GreetingWorkflowImpl.class,
+            testEnv.getWorkflowClient());
+  }
+
+  @After
+  public void tearDown() {
+    testEnv.close();
+  }
+
+  @Test
+  public void testActivityImpl() {
+    Worker activityWorker = testEnv.newWorker(ACTIVITY_TASK_QUEUE);
+    activityWorker.registerActivitiesImplementations(greatActivity);
+    testEnv.start();
+
+    // Execute a workflow waiting for it to complete.
+    String greeting = workflow.getGreeting("World");
+    assertEquals("Hello World!", greeting);
+  }
+}

--- a/src/test/java/ai/applica/spring/boot/starter/temporal/samples/apps/HelloActivitySepareteWorker.java
+++ b/src/test/java/ai/applica/spring/boot/starter/temporal/samples/apps/HelloActivitySepareteWorker.java
@@ -1,0 +1,129 @@
+/*
+ *  Copyright (c) 2020 Applica.ai All Rights Reserved
+ *
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package ai.applica.spring.boot.starter.temporal.samples.apps;
+
+import ai.applica.spring.boot.starter.temporal.WorkflowFactory;
+import ai.applica.spring.boot.starter.temporal.annotations.ActivityStub;
+import ai.applica.spring.boot.starter.temporal.annotations.TemporalActivity;
+import ai.applica.spring.boot.starter.temporal.annotations.TemporalWorkflow;
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+/**
+ * Hello World Temporal workflow that executes a single activity. Requires a local instance the
+ * Temporal service to be running.
+ */
+public class HelloActivitySepareteWorker {
+
+  static final String WORKFLOW_TASK_QUEUE = "HelloActivitySepareteWorkerWorkflow";
+  static final String ACTIVITY_TASK_QUEUE = "HelloActivitySepareteWorkerActivity";
+
+  /** Workflow interface has to have at least one method annotated with @WorkflowMethod. */
+  @WorkflowInterface
+  public interface GreetingSeparateWorkflow {
+    /** @return greeting string */
+    @WorkflowMethod
+    String getGreeting(String name);
+  }
+
+  /** Activity interface is just a POJI. */
+  @ActivityInterface
+  public interface GreetingActivities {
+    @ActivityMethod
+    String composeGreeting(String greeting, String name);
+  }
+
+  /** GreetingWorkflow implementation that calls GreetingsActivities#composeGreeting. */
+  @Component
+  @TemporalWorkflow(WORKFLOW_TASK_QUEUE)
+  public static class GreetingWorkflowImpl implements GreetingSeparateWorkflow {
+
+    /**
+     * Activity stub implements activity interface and proxies calls to it to Temporal activity
+     * invocations. Because activities are reentrant, only a single stub can be used for multiple
+     * activity invocations.
+     */
+    @ActivityStub(taskQueue = ACTIVITY_TASK_QUEUE)
+    private GreetingActivities activities;
+
+    @Override
+    public String getGreeting(String name) {
+      // This is a blocking call that returns only after the activity has completed.
+      return activities.composeGreeting("Hello", name);
+    }
+  }
+
+  @Service
+  static class SimpleExclamationBean {
+    public String getExclamation() {
+      return "!";
+    }
+  }
+
+  @Service
+  @TemporalActivity(ACTIVITY_TASK_QUEUE)
+  static class GreetingActivitiesImpl implements GreetingActivities {
+
+    @Autowired private SimpleExclamationBean simpleExclamationBean;
+
+    @Override
+    public String composeGreeting(String greeting, String name) {
+      return greeting + " " + name + simpleExclamationBean.getExclamation();
+    }
+  }
+
+  // FIXME
+  // @EnableTemporal
+  // @SpringBootApplication
+  public static class GreetingWorkflowRequester implements CommandLineRunner {
+
+    @Autowired private WorkflowFactory fact;
+
+    public void run(String... input) throws Exception {
+      // Start a workflow execution. Usually this is done from another program or bean.
+      // Uses task queue from the GreetingWorkflow @WorkflowMethod annotation.
+      GreetingSeparateWorkflow workflow =
+          fact.makeStub(GreetingSeparateWorkflow.class, GreetingWorkflowImpl.class);
+
+      // Execute a workflow waiting for it to complete. See {@link
+      // io.temporal.samples.hello.HelloSignal}
+      // for an example of starting workflow without waiting synchronously for its result.
+      String greeting = workflow.getGreeting("World");
+      System.out.println("\n\n");
+      System.out.println(greeting);
+      System.out.println("\n\n");
+      System.exit(0);
+    }
+  }
+
+  public static void main(String[] args) {
+    // Wait for workflow completion.
+    SpringApplication.run(GreetingWorkflowRequester.class, args);
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -69,4 +69,6 @@ spring.temporal:
   activityWorkers:
     HelloActivitySepareteWorkerActivity:
       taskQueue: HelloActivitySepareteWorkerActivity
+    SimpleActivity:
+      taskQueue: SimpleActivity
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -30,6 +30,10 @@ spring.temporal:
     "[PropertiesDotWorkflow.PropertiesActivity]":
       scheduleToCloseTimeout: 2
       scheduleToCloseTimeoutUnit: SECONDS
+    "[GreetingSeparateWorkflow.GreetingActivities]":
+      taskQueue: HelloActivitySepareteWorkerActivity
+      scheduleToCloseTimeout: 2
+      scheduleToCloseTimeoutUnit: SECONDS
   workflowDefaults:
     executiontimeout: 1000
     executiontimeoutUnit: SECONDS
@@ -58,3 +62,11 @@ spring.temporal:
       executiontimeoutUnit: DAYS
     HelloProperties:
       taskQueue: HelloProperties
+    HelloActivitySepareteWorkerWorkflow:
+      taskQueue: HelloActivitySepareteWorkerWorkflow
+  activityWorkerDefaults:
+    activityPoolSize: 10
+  activityWorkers:
+    HelloActivitySepareteWorkerActivity:
+      taskQueue: HelloActivitySepareteWorkerActivity
+


### PR DESCRIPTION
This fixes Activity only workers #4.
However as it turned out user in case of Activities ans Workflows being on separated Workers need to provide `taskQueue`. So there is no need for `createWorker` library will see that there is `taskQueue` provided and restrain from building Activiti bean and adding it to Workflow Worker. 