### PR TITLE
Add maven repository url to README for maven projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ implementation 'com.github.applicaai:spring-boot-starter-temporal:0.7.0-SNAPSHOT
     <version>0.7.0-SNAPSHOT</version>
 </dependency>
 ```
+
+```maven
+<repository>
+    <id>oss-repo</id>
+    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+    </snapshots>
+</repository>
+```
 ## Usage
 
 Instead of reading this README you can see examples in test directory `samples` folder.


### PR DESCRIPTION
*Changes*

* Update README to contain remote nexus repository for maven dependency (Fixes https://github.com/applicaai/spring-boot-starter-temporal/issues/5)