### PR TITLE
Add worker poll thread configuration for workflow and activity workers

### DIFF
--- a/src/main/java/ai/applica/spring/boot/starter/temporal/config/TemporalProperties.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/config/TemporalProperties.java
@@ -67,6 +67,10 @@ public class TemporalProperties {
     private Integer activityPoolSize;
 
     private Integer workflowPoolSize;
+
+    private Integer activityPollThreadPoolSize;
+
+    private Integer workflowPollThreadPoolSize;
   }
 
   /**
@@ -117,6 +121,14 @@ public class TemporalProperties {
               if (value.getWorkflowPoolSize() == null) {
                 value.setWorkflowPoolSize(workflowDefaults.getWorkflowPoolSize());
               }
+              if (value.getWorkflowPollThreadPoolSize() == null) {
+                value.setWorkflowPollThreadPoolSize(
+                    workflowDefaults.getWorkflowPollThreadPoolSize());
+              }
+              if (value.getActivityPollThreadPoolSize() == null) {
+                value.setActivityPollThreadPoolSize(
+                    workflowDefaults.getActivityPollThreadPoolSize());
+              }
               addedDefaultsToWorkflows = true;
             });
       }
@@ -140,6 +152,14 @@ public class TemporalProperties {
               }
               if (value.getWorkflowPoolSize() == null) {
                 value.setWorkflowPoolSize(activityWorkerDefaults.getWorkflowPoolSize());
+              }
+              if (value.getWorkflowPollThreadPoolSize() == null) {
+                value.setWorkflowPollThreadPoolSize(
+                    workflowDefaults.getWorkflowPollThreadPoolSize());
+              }
+              if (value.getActivityPollThreadPoolSize() == null) {
+                value.setActivityPollThreadPoolSize(
+                    workflowDefaults.getActivityPollThreadPoolSize());
               }
               addedDefaultsToActivities = true;
             });

--- a/src/main/java/ai/applica/spring/boot/starter/temporal/config/TemporalProperties.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/config/TemporalProperties.java
@@ -154,12 +154,10 @@ public class TemporalProperties {
                 value.setWorkflowPoolSize(activityWorkerDefaults.getWorkflowPoolSize());
               }
               if (value.getWorkflowPollThreadPoolSize() == null) {
-                value.setWorkflowPollThreadPoolSize(
-                    workflowDefaults.getWorkflowPollThreadPoolSize());
+                value.setWorkflowPollThreadPoolSize(workflowDefaults.getWorkflowPollThreadPoolSize());
               }
               if (value.getActivityPollThreadPoolSize() == null) {
-                value.setActivityPollThreadPoolSize(
-                    workflowDefaults.getActivityPollThreadPoolSize());
+                value.setActivityPollThreadPoolSize(workflowDefaults.getActivityPollThreadPoolSize());
               }
               addedDefaultsToActivities = true;
             });

--- a/src/main/java/ai/applica/spring/boot/starter/temporal/config/TemporalProperties.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/config/TemporalProperties.java
@@ -122,12 +122,10 @@ public class TemporalProperties {
                 value.setWorkflowPoolSize(workflowDefaults.getWorkflowPoolSize());
               }
               if (value.getWorkflowPollThreadPoolSize() == null) {
-                value.setWorkflowPollThreadPoolSize(
-                    workflowDefaults.getWorkflowPollThreadPoolSize());
+                value.setWorkflowPollThreadPoolSize(workflowDefaults.getWorkflowPollThreadPoolSize());
               }
               if (value.getActivityPollThreadPoolSize() == null) {
-                value.setActivityPollThreadPoolSize(
-                    workflowDefaults.getActivityPollThreadPoolSize());
+                value.setActivityPollThreadPoolSize(workflowDefaults.getActivityPollThreadPoolSize());
               }
               addedDefaultsToWorkflows = true;
             });

--- a/src/main/java/ai/applica/spring/boot/starter/temporal/processors/ActivityAnnotationBeanPostProcessor.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/processors/ActivityAnnotationBeanPostProcessor.java
@@ -89,8 +89,11 @@ public class ActivityAnnotationBeanPostProcessor
   private WorkerOptions getWorkerOptions(WorkflowOption option) {
     WorkerOptions.Builder workerOptions =
         WorkerOptions.newBuilder()
-            .setMaxConcurrentActivityExecutionSize(option.getActivityPoolSize())
-            .setActivityPollThreadCount(option.getActivityPollThreadPoolSize());
+            .setMaxConcurrentActivityExecutionSize(option.getActivityPoolSize());
+
+    if (option.getActivityPollThreadPoolSize() != null) {
+      workerOptions.setActivityPollThreadCount(option.getActivityPollThreadPoolSize());
+    }
     if (option.getWorkflowPoolSize() != null) {
       workerOptions.setMaxConcurrentWorkflowTaskExecutionSize(option.getWorkflowPoolSize());
     }

--- a/src/main/java/ai/applica/spring/boot/starter/temporal/processors/ActivityAnnotationBeanPostProcessor.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/processors/ActivityAnnotationBeanPostProcessor.java
@@ -89,9 +89,13 @@ public class ActivityAnnotationBeanPostProcessor
   private WorkerOptions getWorkerOptions(WorkflowOption option) {
     WorkerOptions.Builder workerOptions =
         WorkerOptions.newBuilder()
-            .setMaxConcurrentActivityExecutionSize(option.getActivityPoolSize());
+            .setMaxConcurrentActivityExecutionSize(option.getActivityPoolSize())
+            .setActivityPollThreadCount(option.getActivityPollThreadPoolSize());
     if (option.getWorkflowPoolSize() != null) {
       workerOptions.setMaxConcurrentWorkflowTaskExecutionSize(option.getWorkflowPoolSize());
+    }
+    if (option.getWorkflowPollThreadPoolSize() != null) {
+      workerOptions.setWorkflowPollThreadCount(option.getWorkflowPollThreadPoolSize());
     }
     return workerOptions.build();
   }

--- a/src/main/java/ai/applica/spring/boot/starter/temporal/processors/WorkflowAnnotationBeanPostProcessor.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/processors/WorkflowAnnotationBeanPostProcessor.java
@@ -148,8 +148,11 @@ public class WorkflowAnnotationBeanPostProcessor
   private WorkerOptions getWorkerOptions(WorkflowOption option) {
     WorkerOptions.Builder workerOptions =
         WorkerOptions.newBuilder()
-            .setMaxConcurrentWorkflowTaskExecutionSize(option.getWorkflowPoolSize())
-            .setWorkflowPollThreadCount(option.getWorkflowPollThreadPoolSize());
+            .setMaxConcurrentWorkflowTaskExecutionSize(option.getWorkflowPoolSize());
+
+    if (option.getWorkflowPollThreadPoolSize() != null) {
+      workerOptions.setWorkflowPollThreadCount(option.getWorkflowPollThreadPoolSize());
+    }
     if (option.getActivityPoolSize() != null) {
       workerOptions.setMaxConcurrentActivityExecutionSize(option.getActivityPoolSize());
     }

--- a/src/main/java/ai/applica/spring/boot/starter/temporal/processors/WorkflowAnnotationBeanPostProcessor.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/processors/WorkflowAnnotationBeanPostProcessor.java
@@ -148,9 +148,13 @@ public class WorkflowAnnotationBeanPostProcessor
   private WorkerOptions getWorkerOptions(WorkflowOption option) {
     WorkerOptions.Builder workerOptions =
         WorkerOptions.newBuilder()
-            .setMaxConcurrentWorkflowTaskExecutionSize(option.getWorkflowPoolSize());
+            .setMaxConcurrentWorkflowTaskExecutionSize(option.getWorkflowPoolSize())
+            .setWorkflowPollThreadCount(option.getWorkflowPollThreadPoolSize());
     if (option.getActivityPoolSize() != null) {
       workerOptions.setMaxConcurrentActivityExecutionSize(option.getActivityPoolSize());
+    }
+    if (option.getActivityPollThreadPoolSize() != null) {
+      workerOptions.setActivityPollThreadCount(option.getActivityPollThreadPoolSize());
     }
     return workerOptions.build();
   }


### PR DESCRIPTION
This PR is adding the ability to configure the number of polling threads per worker from the temporal server.
Currently the default number of poller threads is defined by the java SDK (2 pollers for workflow worker and 5 pollers for activity worker) which is not sufficient for a high scale and low latency system.