### PR TITLE
Fixes ActivityOptionsModifier

### DIFF
--- a/src/main/java/ai/applica/spring/boot/starter/temporal/InvalidOptionsModifierArgumentException.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/InvalidOptionsModifierArgumentException.java
@@ -1,0 +1,10 @@
+package ai.applica.spring.boot.starter.temporal;
+
+public class InvalidOptionsModifierArgumentException extends RuntimeException {
+  public InvalidOptionsModifierArgumentException(Class expectedArgumentType) {
+    super(
+        "Expected Class<"
+            + expectedArgumentType.getSimpleName()
+            + "> as first argument of method annotated with @ActivityOptionsModifier");
+  }
+}

--- a/src/main/java/ai/applica/spring/boot/starter/temporal/InvalidOptionsModifierArgumentException.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/InvalidOptionsModifierArgumentException.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (c) 2020 Applica.ai All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package ai.applica.spring.boot.starter.temporal;
 
 public class InvalidOptionsModifierArgumentException extends RuntimeException {

--- a/src/main/java/ai/applica/spring/boot/starter/temporal/annotations/ActivityOptionsModifier.java
+++ b/src/main/java/ai/applica/spring/boot/starter/temporal/annotations/ActivityOptionsModifier.java
@@ -23,7 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotate method to change options for activity stub in a workflow. Method will be methed to
+ * Annotate method to change options for activity stub in a workflow. Method will be matched to
  * activity stub based on first argument type.
  *
  * <pre>

--- a/src/test/java/ai/applica/spring/boot/starter/temporal/samples/HelloActivityOptionsModifierTest.java
+++ b/src/test/java/ai/applica/spring/boot/starter/temporal/samples/HelloActivityOptionsModifierTest.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (c) 2020 Applica.ai All Rights Reserved
+ *
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package ai.applica.spring.boot.starter.temporal.samples;
+
+import static ai.applica.spring.boot.starter.temporal.samples.apps.HelloActivityOptionsModifier.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import ai.applica.spring.boot.starter.temporal.WorkflowFactory;
+import ai.applica.spring.boot.starter.temporal.annotations.TemporalTest;
+import ai.applica.spring.boot.starter.temporal.extensions.TemporalTestWatcher;
+import ai.applica.spring.boot.starter.temporal.samples.apps.HelloActivityOptionsModifier;
+import io.temporal.api.enums.v1.RetryState;
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.failure.ActivityFailure;
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.worker.Worker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/** Unit test for {@link HelloActivityOptionsModifier}. Doesn't use an external Temporal service. */
+@SpringBootTest
+@TemporalTest
+class HelloActivityOptionsModifierTest {
+
+  private TestWorkflowEnvironment testEnv;
+  private Worker worker;
+  GreetingWorkflow workflow;
+
+  @RegisterExtension TemporalTestWatcher temporalTestWatcher = new TemporalTestWatcher();
+  @Autowired WorkflowFactory fact;
+  @Autowired GreetingActivities greatActivity;
+
+  @BeforeEach
+  public void setUp() {
+    testEnv = TestWorkflowEnvironment.newInstance();
+    temporalTestWatcher.setEnvironment(testEnv);
+    worker = fact.makeWorker(testEnv, GreetingWorkflowImpl.class);
+
+    // Get a workflow stub using the same task queue the worker uses.
+    workflow =
+        fact.makeStub(
+            GreetingWorkflow.class, GreetingWorkflowImpl.class, testEnv.getWorkflowClient());
+  }
+
+  @AfterEach
+  public void tearDown() {
+    testEnv.close();
+  }
+
+  @Test
+  @Timeout(1)
+  void testHappyPath() {
+    worker.registerActivitiesImplementations(greatActivity);
+    testEnv.start();
+
+    // Execute a workflow waiting for it to complete.
+    String greeting = workflow.getGreeting("World");
+
+    assertThat(greeting).isEqualTo("Hello World!");
+  }
+
+  @Test
+  @Timeout(1)
+  void testRetryWithFailure() {
+    // given
+    GreetingActivities activities = mock(GreetingActivities.class);
+    when(activities.composeGreeting("Hello", "World"))
+        .thenThrow(new IllegalStateException("not yet1"), new IllegalStateException("not yet2"))
+        .thenReturn("Hello World!");
+    worker.registerActivitiesImplementations(activities);
+    testEnv.start();
+
+    // when
+    WorkflowFailedException exception =
+        assertThrows(WorkflowFailedException.class, () -> workflow.getGreeting("World"));
+
+    // then
+    Throwable cause = exception.getCause();
+    assertEquals(cause.getClass(), ActivityFailure.class);
+    assertEquals(
+        ((ActivityFailure) cause).getRetryState(), RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED);
+  }
+}

--- a/src/test/java/ai/applica/spring/boot/starter/temporal/samples/apps/HelloActivityOptionsModifier.java
+++ b/src/test/java/ai/applica/spring/boot/starter/temporal/samples/apps/HelloActivityOptionsModifier.java
@@ -21,28 +21,25 @@
 
 package ai.applica.spring.boot.starter.temporal.samples.apps;
 
-import ai.applica.spring.boot.starter.temporal.WorkflowFactory;
+import ai.applica.spring.boot.starter.temporal.annotations.ActivityOptionsModifier;
 import ai.applica.spring.boot.starter.temporal.annotations.ActivityStub;
 import ai.applica.spring.boot.starter.temporal.annotations.TemporalWorkflow;
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityOptions;
 import io.temporal.common.RetryOptions;
-import io.temporal.workflow.Functions;
 import io.temporal.workflow.WorkflowInterface;
 import io.temporal.workflow.WorkflowMethod;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.SpringApplication;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 /**
- * Demonstrates activity retries using an exponential backoff algorithm. Requires a local instance
- * of the Temporal service to be running.
+ * Demonstrates activity options modifier. Requires a local instance of the Temporal service to be
+ * running.
  */
-public class HelloActivityRetry {
+public class HelloActivityOptionsModifier {
 
-  static final String TASK_QUEUE = "HelloActivityRetry";
+  static final String TASK_QUEUE = "HelloActivityOptionsModifier";
+  private static int MAX_ATTEMPTS = 2;
 
   @WorkflowInterface
   public interface GreetingWorkflow {
@@ -64,13 +61,19 @@ public class HelloActivityRetry {
   @TemporalWorkflow(TASK_QUEUE)
   public static class GreetingWorkflowImpl implements GreetingWorkflow {
 
-    /**
-     * To enable activity retry set {@link RetryOptions} on {@link ActivityOptions}. It also works
-     * for activities invoked through {@link io.temporal.workflow.Async#function(Functions.Func)}
-     * and for child workflows.
-     */
     @ActivityStub(startToClose = "PT10S")
     private GreetingActivities activities;
+
+    @ActivityOptionsModifier
+    private ActivityOptions.Builder modifyOptions(
+        Class<GreetingActivities> cls, ActivityOptions.Builder options) {
+      options.setRetryOptions(
+          RetryOptions.newBuilder()
+              .setMaximumAttempts(
+                  MAX_ATTEMPTS) // sets maximum attempts to call activity before ActivityFailure
+              .build());
+      return options;
+    }
 
     @Override
     public String getGreeting(String name) {
@@ -82,48 +85,14 @@ public class HelloActivityRetry {
   @Service
   public static class GreetingActivitiesImpl implements GreetingActivities {
     private int callCount;
-    private long lastInvocationTime;
 
     @Override
     public synchronized String composeGreeting(String greeting, String name) {
-      if (lastInvocationTime != 0) {
-        long timeSinceLastInvocation = System.currentTimeMillis() - lastInvocationTime;
-        System.out.print(timeSinceLastInvocation + " milliseconds since last invocation. ");
-      }
-      lastInvocationTime = System.currentTimeMillis();
-      if (++callCount < 4) {
+      if (++callCount < MAX_ATTEMPTS) {
         System.out.println("composeGreeting activity is going to fail");
         throw new IllegalStateException("not yet");
       }
-      System.out.println("composeGreeting activity is going to complete");
       return greeting + " " + name + "!";
     }
-  }
-  // FIXME
-  // @EnableTemporal
-  // @SpringBootApplication
-  public static class GreetingWorkflowRequester implements CommandLineRunner {
-
-    @Autowired private WorkflowFactory fact;
-
-    public void run(String... input) throws Exception {
-      // Start a workflow execution. Usually this is done from another program or bean.
-      // Uses task queue from the GreetingWorkflow @WorkflowMethod annotation.
-      GreetingWorkflow workflow = fact.makeStub(GreetingWorkflow.class, GreetingWorkflowImpl.class);
-
-      // Execute a workflow waiting for it to complete. See {@link
-      // io.temporal.samples.hello.HelloSignal}
-      // for an example of starting workflow without waiting synchronously for its result.
-      String greeting = workflow.getGreeting("World");
-      System.out.println("\n\n");
-      System.out.println(greeting);
-      System.out.println("\n\n");
-      System.exit(0);
-    }
-  }
-
-  public static void main(String[] args) {
-    // Wait for workflow completion.
-    SpringApplication.run(GreetingWorkflowRequester.class, args);
   }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -52,6 +52,8 @@ spring.temporal:
       taskQueue: HelloActivityRetry
     HelloActivityAnnotation:
       taskQueue: HelloActivityAnnotation
+    HelloActivityOptionsModifier:
+      taskQueue: HelloActivityOptionsModifier
     HelloChild:
       taskQueue: HelloChild
     HelloQuery:


### PR DESCRIPTION
### Current behavior
`ActivityStubInterceptor` only looks for parametrized type, so in case of valid options modifier method (with `Class<ActivityType>` as first argument) it always finds `Class`. Eventually options modifier method is never called.

### Behavior after merge
`ActivityStubInterceptor` will look for generic parametrized type actual value of first `ActivityOptionsModifier` annotation argument. For `Class<ActivityType>` it will find `ActivityType`.